### PR TITLE
basic-auth-token option for bypassing sso

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -34,11 +34,12 @@ func main() {
 	}
 
 	sso := &sso.SSO{
-		UpstreamURL:   upstreamURL,
-		APIURL:        apiURL,
-		AppPublicURL:  appPublicURL,
-		EncryptionKey: []byte("sa8OoLei6eWiezah9ohk8Wah6Ow6pee9"),
-		CSRFAuthKey:   []byte("oxei9aebonogh1Gaina4ePaitheechei"),
+		UpstreamURL:    upstreamURL,
+		APIURL:         apiURL,
+		AppPublicURL:   appPublicURL,
+		EncryptionKey:  []byte("sa8OoLei6eWiezah9ohk8Wah6Ow6pee9"),
+		CSRFAuthKey:    []byte("oxei9aebonogh1Gaina4ePaitheechei"),
+		BasicAuthToken: []byte("ed8ohK6yai1OdeeQuaiYohXuv0Ooc6oo"),
 		Authorized: func(u sso.User) (bool, error) {
 			return true, nil
 		},

--- a/cmd/sso/main.go
+++ b/cmd/sso/main.go
@@ -22,6 +22,8 @@ var csrfAuthKey = flag.String("csrf-key", "", "key used for cookie authenticated
 
 var authorizedUsers = flag.String("authorized-users", "", "comma-separated list of users that are authorized to use the app")
 
+var basicAuthToken = flag.String("basic-auth-token", "", "token for bypassing sso via basic auth")
+
 func isDir(pth string) (bool, error) {
 	fi, err := os.Stat(pth)
 	if err != nil {
@@ -93,11 +95,12 @@ func main() {
 	}
 
 	sso := &sso.SSO{
-		UpstreamURL:   upstreamURL,
-		APIURL:        apiURL,
-		AppPublicURL:  appPublicURL,
-		EncryptionKey: []byte(*encryptionKey),
-		CSRFAuthKey:   []byte(*csrfAuthKey),
+		UpstreamURL:    upstreamURL,
+		APIURL:         apiURL,
+		AppPublicURL:   appPublicURL,
+		EncryptionKey:  []byte(*encryptionKey),
+		CSRFAuthKey:    []byte(*csrfAuthKey),
+		BasicAuthToken: []byte(*basicAuthToken),
 		Authorized: func(u sso.User) (bool, error) {
 			return authorized[u.Login], nil
 		},


### PR DESCRIPTION
the main use case for this is to be able to call into sso-protected apis via basic auth. for example for hosting something like https://zipkin.io/.